### PR TITLE
Discrepancy between --from-scratch and --scratch

### DIFF
--- a/antrax/classifier.py
+++ b/antrax/classifier.py
@@ -482,7 +482,7 @@ class axClassifier:
 
         if self.trained and (classes != self.classes):
 
-            print('-E- Class list in example dir does not match classifier. Use --from-scratch to train a new model')
+            print('-E- Class list in example dir does not match classifier. Use --scratch to train a new model')
             return
 
         # create data generators


### PR DESCRIPTION
The docs suggest to use `--scratch` and this error message suggests to use `--from-scratch`, but the latter one doesn't work. Not a big issue per se, but can be confusing.